### PR TITLE
Return `res` in accessAttempt to fix chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ function handler(opts) {
 				opts.onDelayedResponse(req, method, args, requestTime);
 				opts.onDelayedResponse = null; //only call onDelayedResponse once
 			}
+			return res
 		}
 
 		next();


### PR DESCRIPTION
It is reasonable in express to do this:

```js
res.status(200).json({ foo: 'bar' })
```

This doesn't work if you are using `express-timeout-handler` and the request has timed out, because the monkey patched function `accessAttempt` does not return `res`.